### PR TITLE
Fix team member urls

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -12,8 +12,8 @@
                 {% for member in sorted_team %}
                 <div class="col-sm-3 col-centered">
                     <div class="team-member">
-                        {% if member.url %}
-                        <a href="{{ member.url }}" target="_blank"><img src="/assets/img/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt=""></a>
+                        {% if member.profile_url %}
+                        <a href="{{ member.profile_url }}" target="_blank"><img src="/assets/img/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt=""></a>
                         {% else %}
                         <img src="/assets/img/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt="">
                         {% endif %}

--- a/_team/you.md
+++ b/_team/you.md
@@ -1,7 +1,7 @@
 ---
 name: You?
 pic: 11
-url: https://xebia.com/careers/datacenter-automation-hero
+profile_url: https://xebia.com/careers/datacenter-automation-hero
 tagline: Data Center Automation Wizard
 social:
     - title: question-circle


### PR DESCRIPTION
Renamed url property to profile_url, because it clashed with default url property for collections.